### PR TITLE
Fix for Webpack 2's loader suffix breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/lodash": "^4.14.34",
     "@types/requirejs": "^2.1.26",
     "@types/webpack": "^1.12.34",
-    "bootstrap-loader": "^2.0.0-beta.12",
+    "bootstrap-loader": "2.0.0-beta.16",
     "bootstrap-sass": "^3.3.6",
     "core-js": "^2.4.1",
     "css-loader": "^0.23.1",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,4 +1,4 @@
-require('script!jquery/dist/jquery.js');
+require('script-loader!jquery/dist/jquery.js');
 require('bootstrap-loader');
 
 require('core-js/es6');


### PR DESCRIPTION
This ugprades bootstrap-loader to be compatible with the latest breaking changes of Webpack 2 that requires all loaders to be suffixed with `-loader` and also fixes a missing `-loader` suffix in the `bootstrap.ts` file