### PR TITLE
Add a2d3RedrawRequest event to listen to force redraw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2d3",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "description": "AngularJS chart directives and other integrations for D3.js",
   "authors": [
     "Chris Nicola <chris.nicola@wealthbar.com>"

--- a/src/angularD3/directives/chart.ts
+++ b/src/angularD3/directives/chart.ts
@@ -33,6 +33,7 @@ export class D3Chart implements OnInit {
     this.element = elementRef.nativeElement;
     this.chart = d3.select(this.element).attr('class', "d3-chart")
     window.addEventListener('resize', () => this.redraw())
+    window.addEventListener('a2d3RedrawRequest', () => this.redraw())
   }
 
   get width() { return this.element.clientWidth; }


### PR DESCRIPTION
To be able to specifically trigger a2d3 redraws without hijacking existing events, this PR adds a new event listener on `a2d3RedrawRequest` that forces d3Chart to run the redraw method.